### PR TITLE
Add Git branch name in GEOSERVER_NODE_OPTS

### DIFF
--- a/doc/en/user/source/configuration/properties/index.rst
+++ b/doc/en/user/source/configuration/properties/index.rst
@@ -3,11 +3,11 @@
 Application Properties
 ----------------------
 
-While many configuration and setup options are available through the Web Administration application :menuselection:`Settings > Global` page, more fundamental (and security minded) changes to how the application operates are made using "Application Properties" defined by:
+While many configuration and setup options are available through the Web Administration application :menuselection:`Settings > Global` page, more fundamental (and security minded) changes to how the application operates are made using "Application Properties" defined by (in order of priority):
 
-* Java System Properties
-* Web Application context parameters
-* System Environmental Variable
+  1. Java System Properties
+  2. Web Application context parameters
+  3. System Environmental Variables
 
 As part of the operating environment GeoServer application properties, unlike settings, cannot be changed at runtime.
 

--- a/doc/en/user/source/production/identify.rst
+++ b/doc/en/user/source/production/identify.rst
@@ -7,12 +7,15 @@ When running one or more clusters of GeoServer installations it is useful to ide
 cluster (and eventually which node of the cluster) one is working against by just glancing at
 the web administration UI.
 
-This is possible by setting one variable, ``GEOSERVER_NODE_OPTS``, with one of the supported
-mechanisms:
+It can also be used to display the Git branch the node is running from, which can be useful
+when testing new features or bug fixes.
 
-  * as a system variable
-  * as an environment variable
-  * as a servlet context parameter
+This is possible by setting one variable, ``GEOSERVER_NODE_OPTS``, with one of the supported
+mechanisms (in order of priority):
+
+  1. Java System Properties
+  2. Web Application context parameters
+  3. System Environmental Variables
 
 ``GEOSERVER_NODE_OPTS`` is a semicolon separated list of key/value pairs and it can contain the following keys:
 
@@ -22,6 +25,7 @@ mechanisms:
     * ``$host_name``: the hostname of the node
     * ``$host_short_name``: the hostname truncated to not include the domain (``foo.local`` becomes ``foo``)
     * ``$host_compact_name``: the hostname with all domain parts shortened to their first character (``foo.local`` becomes ``foo.l``)
+    * ``$git_branch``: the Git branch name (requires the ``.git`` folder to be present in the GEOSERVER_DATA_DIR, its immediate parent or the current working directory)
 
   * ``color``: the label color, as a CSS color
   * ``background``: the background color, as a CSS color

--- a/src/main/src/main/java/org/geoserver/GeoServerNodeData.java
+++ b/src/main/src/main/java/org/geoserver/GeoServerNodeData.java
@@ -9,6 +9,8 @@ import com.google.common.collect.Streams;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.UnknownHostException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -80,6 +82,7 @@ public class GeoServerNodeData {
                 Map<String, String> options = parseProperties(nodeOpts);
                 String id = options.get("id");
                 if (id != null) {
+                    // first handle the host-based substitutions ($host_ip, $host_name, etc.)
                     if (SUBSTITUTIONS.keySet().stream().anyMatch(id::contains)) {
                         final InetAddress address = getLocalHostLANAddress();
                         for (Entry<String, Function<InetAddress, String>> e : SUBSTITUTIONS.entrySet()) {
@@ -87,6 +90,18 @@ public class GeoServerNodeData {
                             final String value = e.getValue().apply(address);
                             id = id.replace(token, value);
                         }
+                    }
+
+                    // now handle simple tokens like $git_branch
+                    try {
+                        if (id.contains("$git_branch")) {
+                            String gitBranch = resolveGitBranch();
+                            if (gitBranch != null) {
+                                id = id.replace("$git_branch", gitBranch);
+                            }
+                        }
+                    } catch (Exception e) {
+                        LOGGER.log(Level.FINE, "Failed to resolve extended tokens", e);
                     }
                 }
 
@@ -130,6 +145,79 @@ public class GeoServerNodeData {
     @VisibleForTesting
     static void clearMockAddress() {
         GeoServerNodeData.mockAddress = null;
+    }
+
+    // --- Testing hooks and extended token helpers ---
+    private static Path overrideGitHeadPath = null;
+
+    @VisibleForTesting
+    static void setOverrideGitHeadPath(Path path) {
+        overrideGitHeadPath = path;
+    }
+
+    @VisibleForTesting
+    static void clearOverrideGitHeadPath() {
+        overrideGitHeadPath = null;
+    }
+
+    private static String defaultString(String s) {
+        return s == null ? "" : s;
+    }
+
+    private static String resolveGitBranch() {
+        try {
+            // 1) test override (fast path for unit tests)
+            Path gitHead = overrideGitHeadPath;
+
+            // 2) check GEOSERVER_DATA_DIR (system property then context then env) and its parent
+            if (gitHead == null) {
+                String dataDir = GeoServerExtensions.getProperty("GEOSERVER_DATA_DIR");
+                if (dataDir != null && !dataDir.isEmpty()) {
+                    Path dataGit = Path.of(dataDir).resolve(".git").resolve("HEAD");
+                    if (Files.exists(dataGit)) {
+                        gitHead = dataGit;
+                    } else {
+                        Path parent = Path.of(dataDir).getParent();
+                        if (parent != null) {
+                            Path parentGit = parent.resolve(".git").resolve("HEAD");
+                            if (Files.exists(parentGit)) {
+                                gitHead = parentGit;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // 3) fall back to repo-local .git/HEAD
+            if (gitHead == null) {
+                gitHead = Path.of(".git", "HEAD");
+            }
+
+            if (!Files.exists(gitHead)) {
+                return null;
+            }
+
+            LOGGER.log(
+                    Level.FINE,
+                    "Resolving git branch from " + gitHead.toAbsolutePath().toString());
+
+            List<String> lines = Files.readAllLines(gitHead);
+            if (lines.isEmpty()) {
+                return null;
+            }
+            String first = lines.get(0).trim();
+            if (first.startsWith("ref: ")) {
+                String ref = first.substring("ref: ".length()).trim();
+                if (ref.startsWith("refs/heads/")) {
+                    return ref.substring("refs/heads/".length());
+                }
+                return ref;
+            }
+            return first;
+        } catch (Exception ex) {
+            LOGGER.log(Level.INFO, "Error resolving git branch", ex);
+            return null;
+        }
     }
 
     static InetAddress getLocalHostLANAddress() throws UnknownHostException {

--- a/src/main/src/main/java/org/geoserver/GeoServerNodeData.java
+++ b/src/main/src/main/java/org/geoserver/GeoServerNodeData.java
@@ -160,10 +160,6 @@ public class GeoServerNodeData {
         overrideGitHeadPath = null;
     }
 
-    private static String defaultString(String s) {
-        return s == null ? "" : s;
-    }
-
     private static String resolveGitBranch() {
         try {
             // 1) test override (fast path for unit tests)

--- a/src/main/src/test/java/org/geoserver/GeoServerNodeDataTest.java
+++ b/src/main/src/test/java/org/geoserver/GeoServerNodeDataTest.java
@@ -9,6 +9,9 @@ import static org.junit.Assert.assertNotNull;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -26,6 +29,7 @@ public class GeoServerNodeDataTest {
     @After
     public void cleanUp() {
         GeoServerNodeData.clearMockAddress();
+        GeoServerNodeData.clearOverrideGitHeadPath();
     }
 
     @Test
@@ -61,5 +65,142 @@ public class GeoServerNodeDataTest {
         GeoServerNodeData data = GeoServerNodeData.createFromString("id:$host_compact_name");
         assertEquals("test.l", data.getId());
         assertNotNull(data.getIdStyle());
+    }
+
+    @Test
+    public void testGitBranchToken() throws Exception {
+        Path tmp = Files.createTempDirectory("githead");
+        try {
+            Path head = tmp.resolve(".git").resolve("HEAD");
+            Files.createDirectories(head.getParent());
+            Files.writeString(head, "ref: refs/heads/feature/test\n");
+
+            GeoServerNodeData.setOverrideGitHeadPath(head);
+            GeoServerNodeData data = GeoServerNodeData.createFromString("id:$git_branch");
+            assertEquals("feature/test", data.getId());
+        } finally {
+            FileUtils.deleteDirectory(tmp.toFile());
+        }
+    }
+
+    @Test
+    public void testGitBranchFromDataDir() throws Exception {
+        Path tmp = Files.createTempDirectory("data-dir");
+        try {
+            Path head = tmp.resolve(".git").resolve("HEAD");
+            Files.createDirectories(head.getParent());
+            Files.writeString(head, "ref: refs/heads/data-branch\n");
+
+            System.setProperty("GEOSERVER_DATA_DIR", tmp.toAbsolutePath().toString());
+            try {
+                GeoServerNodeData data = GeoServerNodeData.createFromString("id:$git_branch");
+                assertEquals("data-branch", data.getId());
+            } finally {
+                System.clearProperty("GEOSERVER_DATA_DIR");
+            }
+        } finally {
+            FileUtils.deleteDirectory(tmp.toFile());
+        }
+    }
+
+    @Test
+    public void testGitBranchFromParentOfDataDir() throws Exception {
+        Path parent = Files.createTempDirectory("parent-dir");
+        try {
+            Path child = parent.resolve("child-data");
+            Files.createDirectories(child);
+
+            Path head = parent.resolve(".git").resolve("HEAD");
+            Files.createDirectories(head.getParent());
+            Files.writeString(head, "ref: refs/heads/parent-branch\n");
+
+            System.setProperty("GEOSERVER_DATA_DIR", child.toAbsolutePath().toString());
+            try {
+                GeoServerNodeData data = GeoServerNodeData.createFromString("id:$git_branch");
+                assertEquals("parent-branch", data.getId());
+            } finally {
+                System.clearProperty("GEOSERVER_DATA_DIR");
+            }
+        } finally {
+            FileUtils.deleteDirectory(parent.toFile());
+        }
+    }
+
+    @Test
+    public void testGitBranchEmptyHeadFile() throws Exception {
+        Path tmp = Files.createTempDirectory("githead");
+        try {
+            Path head = tmp.resolve(".git").resolve("HEAD");
+            Files.createDirectories(head.getParent());
+            Files.writeString(head, "");
+
+            GeoServerNodeData.setOverrideGitHeadPath(head);
+            GeoServerNodeData data = GeoServerNodeData.createFromString("id:$git_branch");
+            assertEquals("$git_branch", data.getId());
+        } finally {
+            FileUtils.deleteDirectory(tmp.toFile());
+        }
+    }
+
+    @Test
+    public void testGitBranchDetachedHead() throws Exception {
+        Path tmp = Files.createTempDirectory("githead");
+        try {
+            Path head = tmp.resolve(".git").resolve("HEAD");
+            Files.createDirectories(head.getParent());
+            Files.writeString(head, "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0\n");
+
+            GeoServerNodeData.setOverrideGitHeadPath(head);
+            GeoServerNodeData data = GeoServerNodeData.createFromString("id:$git_branch");
+            assertEquals("a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0", data.getId());
+        } finally {
+            FileUtils.deleteDirectory(tmp.toFile());
+        }
+    }
+
+    @Test
+    public void testGitBranchRefWithoutHeadsPrefix() throws Exception {
+        Path tmp = Files.createTempDirectory("githead");
+        try {
+            Path head = tmp.resolve(".git").resolve("HEAD");
+            Files.createDirectories(head.getParent());
+            Files.writeString(head, "ref: refs/remotes/origin/main\n");
+
+            GeoServerNodeData.setOverrideGitHeadPath(head);
+            GeoServerNodeData data = GeoServerNodeData.createFromString("id:$git_branch");
+            assertEquals("refs/remotes/origin/main", data.getId());
+        } finally {
+            FileUtils.deleteDirectory(tmp.toFile());
+        }
+    }
+
+    @Test
+    public void testGitBranchNonExistentGitDir() throws Exception {
+        Path tmp = Files.createTempDirectory("nogit");
+        try {
+            Path head = tmp.resolve(".git").resolve("HEAD");
+
+            GeoServerNodeData.setOverrideGitHeadPath(head);
+            GeoServerNodeData data = GeoServerNodeData.createFromString("id:$git_branch");
+            assertEquals("$git_branch", data.getId());
+        } finally {
+            FileUtils.deleteDirectory(tmp.toFile());
+        }
+    }
+
+    @Test
+    public void testGitBranchMissingNewline() throws Exception {
+        Path tmp = Files.createTempDirectory("githead");
+        try {
+            Path head = tmp.resolve(".git").resolve("HEAD");
+            Files.createDirectories(head.getParent());
+            Files.writeString(head, "ref: refs/heads/no-newline");
+
+            GeoServerNodeData.setOverrideGitHeadPath(head);
+            GeoServerNodeData data = GeoServerNodeData.createFromString("id:$git_branch");
+            assertEquals("no-newline", data.getId());
+        } finally {
+            FileUtils.deleteDirectory(tmp.toFile());
+        }
     }
 }


### PR DESCRIPTION
- Implemented functionality to resolve and substitute the Git branch name in node IDs.
- Added unit tests to verify Git branch token resolution from various directory structures.
- Updated documentation to clarify the use of Application Properties (specifically the order).

