### PR TITLE
[GEOS-12127] Remove dangerous noop sync context + merge flaky test fixes

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  MAVEN_OPTS: -Xmx2g -Daether.connector.basic.threads=8 -Daether.metadataResolver.threads=8 -Daether.syncContext.named.time=120 -Daether.syncContext.named.factory=file-lock -Daether.syncContext.named.nameMapper=file-gav -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3 -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dspotless.apply.skip=true -Daether.syncContext.named.time=120 -Daether.syncContext.named.time.unit=SECONDS -Daether.syncContext.named.factory=noop
+  MAVEN_OPTS: -Xmx2g -Daether.connector.basic.threads=8 -Daether.metadataResolver.threads=8 -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3 -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dspotless.apply.skip=true
 
 jobs:
   build:

--- a/.github/workflows/linux_locales.yml
+++ b/.github/workflows/linux_locales.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  MAVEN_OPTS: -Xmx2g -Daether.connector.basic.threads=8 -Daether.metadataResolver.threads=8 -Daether.syncContext.named.time=120 -Daether.syncContext.named.factory=file-lock -Daether.syncContext.named.nameMapper=file-gav -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3 -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dspotless.apply.skip=true -Daether.syncContext.named.time=120 -Daether.syncContext.named.time.unit=SECONDS -Daether.syncContext.named.factory=noop
+  MAVEN_OPTS: -Xmx2g -Daether.connector.basic.threads=8 -Daether.metadataResolver.threads=8 -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3 -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dspotless.apply.skip=true
 
 jobs:
   build:

--- a/.github/workflows/linux_timezone.yml
+++ b/.github/workflows/linux_timezone.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  MAVEN_OPTS: -Xmx2g -Daether.connector.basic.threads=8 -Daether.metadataResolver.threads=8 -Daether.syncContext.named.time=120 -Daether.syncContext.named.factory=file-lock -Daether.syncContext.named.nameMapper=file-gav -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3 -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dspotless.apply.skip=true -Daether.syncContext.named.time=120 -Daether.syncContext.named.time.unit=SECONDS -Daether.syncContext.named.factory=noop
+  MAVEN_OPTS: -Xmx2g -Daether.connector.basic.threads=8 -Daether.metadataResolver.threads=8 -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3 -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dspotless.apply.skip=true
 
 jobs:
   build:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  MAVEN_OPTS: -Xmx2g -Daether.connector.basic.threads=8 -Daether.metadataResolver.threads=8 -Daether.syncContext.named.time=120 -Daether.syncContext.named.factory=file-lock -Daether.syncContext.named.nameMapper=file-gav -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3 -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dspotless.apply.skip=true -Daether.syncContext.named.time=120 -Daether.syncContext.named.time.unit=SECONDS  -Daether.syncContext.named.factory=noop
+  MAVEN_OPTS: -Xmx2g -Daether.connector.basic.threads=8 -Daether.metadataResolver.threads=8 -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3 -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dspotless.apply.skip=true
 
 jobs:
   build:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  MAVEN_OPTS: -Xmx2g -Daether.connector.basic.threads=8 -Daether.metadataResolver.threads=8 -Daether.syncContext.named.time=120 -Daether.syncContext.named.factory=file-lock -Daether.syncContext.named.nameMapper=file-gav -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3 -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dspotless.apply.skip=true -Daether.syncContext.named.time=120 -Daether.syncContext.named.time.unit=SECONDS  -Daether.syncContext.named.factory=noop
+  MAVEN_OPTS: -Xmx2g -Daether.connector.basic.threads=8 -Daether.metadataResolver.threads=8 -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3 -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dspotless.apply.skip=true
 
 jobs:
   build:

--- a/src/extension/metadata/src/test/java/org/geoserver/metadata/AbstractWicketMetadataTest.java
+++ b/src/extension/metadata/src/test/java/org/geoserver/metadata/AbstractWicketMetadataTest.java
@@ -8,6 +8,7 @@ import org.apache.wicket.Component;
 import org.apache.wicket.extensions.markup.html.tabs.ITab;
 import org.apache.wicket.extensions.markup.html.tabs.TabbedPanel;
 import org.apache.wicket.util.tester.WicketTester;
+import org.geoserver.metadata.data.service.impl.ConfigurationServiceImpl;
 import org.geoserver.web.GeoServerApplication;
 import org.geoserver.web.wicket.WicketHierarchyPrinter;
 import org.junit.After;
@@ -19,6 +20,9 @@ public abstract class AbstractWicketMetadataTest extends AbstractMetadataTest {
 
     @Autowired
     protected GeoServerApplication app;
+
+    @Autowired
+    private ConfigurationServiceImpl configService;
 
     protected WicketTester tester;
 
@@ -38,6 +42,13 @@ public abstract class AbstractWicketMetadataTest extends AbstractMetadataTest {
 
     @Before
     public void start() throws Exception {
+        // Defensive: ensure metadata configuration is loaded before creating the WicketTester.
+        // While JUnit 4 guarantees parent @Before (setupAndLoadDataDirectory) runs first,
+        // the config can still be null if readConfiguration() failed silently (YAML files
+        // not yet copied to the data directory, or parse errors logged at FINE level).
+        if (configService.getMetadataConfiguration() == null) {
+            configService.reload();
+        }
         tester = new WicketTester(app, true);
     }
 

--- a/src/extension/monitor/core/src/test/java/org/geoserver/monitor/PipeliningTaskQueueTest.java
+++ b/src/extension/monitor/core/src/test/java/org/geoserver/monitor/PipeliningTaskQueueTest.java
@@ -7,15 +7,17 @@ package org.geoserver.monitor;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
 import java.util.Random;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import org.geotools.util.logging.Logging;
 import org.junit.After;
 import org.junit.Before;
@@ -49,17 +51,87 @@ public class PipeliningTaskQueueTest {
             workers.add(list);
         }
 
+        long submitStart = System.currentTimeMillis();
         for (int i = 0; i < groups; i++) {
             for (int j = 0; j < groups; j++) {
                 Worker w = workers.get(j).get(i);
                 taskQueue.execute(w.group, w);
             }
         }
+        long submitEnd = System.currentTimeMillis();
 
-        await().atMost(60, SECONDS).until(() -> completed.size() >= groups * groups);
+        int totalTasks = groups * groups;
+        try {
+            await().atMost(60, SECONDS).until(() -> completed.size() >= totalTasks);
+        } catch (Exception e) {
+            // Capture diagnostic state on timeout
+            long elapsed = System.currentTimeMillis() - submitEnd;
+            StringBuilder diag = new StringBuilder();
+            diag.append("\n=== PipeliningTaskQueueTest TIMEOUT DIAGNOSTICS ===\n");
+            diag.append("Completed: ").append(completed.size()).append("/").append(totalTasks);
+            diag.append(" after ").append(elapsed).append("ms\n");
+            diag.append("Submit took: ").append(submitEnd - submitStart).append("ms\n");
+            diag.append("Completed workers (group.seq @ startMs/endMs):\n");
+            for (Worker w : completed) {
+                diag.append("  group=")
+                        .append(w.group)
+                        .append(" seq=")
+                        .append(w.seq)
+                        .append(" started=")
+                        .append(w.startTimeMs.get())
+                        .append("ms ended=")
+                        .append(w.endTimeMs.get())
+                        .append("ms slept=")
+                        .append(w.actualSleepMs.get())
+                        .append("ms\n");
+            }
+            // Report which tasks never completed
+            diag.append("Missing workers:\n");
+            for (int g = 0; g < groups; g++) {
+                for (int s = 0; s < groups; s++) {
+                    Worker w = workers.get(g).get(s);
+                    if (w.endTimeMs.get() == 0) {
+                        diag.append("  group=")
+                                .append(w.group)
+                                .append(" seq=")
+                                .append(w.seq)
+                                .append(" started=")
+                                .append(w.startTimeMs.get())
+                                .append("ms\n");
+                    }
+                }
+            }
+            fail(diag.toString() + "\nOriginal exception: " + e.getMessage());
+        }
+
+        // Verify ordering within each group
+        long completionTime = System.currentTimeMillis() - submitEnd;
         int[] status = new int[groups];
-        for (Worker w : completed) {
-            assertEquals(status[w.group], w.seq.intValue());
+        List<Worker> completedList = new ArrayList<>(completed);
+        for (int idx = 0; idx < completedList.size(); idx++) {
+            Worker w = completedList.get(idx);
+            if (status[w.group] != w.seq.intValue()) {
+                // Build diagnostic showing the full completion order for this group
+                String groupOrder = completedList.stream()
+                        .filter(x -> x.group.equals(w.group))
+                        .map(x -> "seq=" + x.seq + "@" + x.endTimeMs.get() + "ms")
+                        .collect(Collectors.joining(", "));
+                fail("Ordering violation at position "
+                        + idx
+                        + ": group="
+                        + w.group
+                        + " expected seq="
+                        + status[w.group]
+                        + " but got seq="
+                        + w.seq
+                        + ". Total completion time: "
+                        + completionTime
+                        + "ms. Group "
+                        + w.group
+                        + " completion order: ["
+                        + groupOrder
+                        + "]");
+            }
             status[w.group]++;
         }
     }
@@ -69,6 +141,9 @@ public class PipeliningTaskQueueTest {
         Integer group;
         Integer seq;
         Queue<Worker> completed;
+        AtomicLong startTimeMs = new AtomicLong();
+        AtomicLong endTimeMs = new AtomicLong();
+        AtomicLong actualSleepMs = new AtomicLong();
 
         public Worker(Integer group, Integer seq, Queue<Worker> completed) {
             this.group = group;
@@ -78,15 +153,19 @@ public class PipeliningTaskQueueTest {
 
         @Override
         public void run() {
+            startTimeMs.set(System.currentTimeMillis());
             Random r = new Random();
             int x = r.nextInt(10) + 1;
             try {
+                long before = System.currentTimeMillis();
                 Thread.sleep(x * 10);
+                actualSleepMs.set(System.currentTimeMillis() - before);
             } catch (InterruptedException e) {
                 LOGGER.log(Level.WARNING, "", e);
             }
 
             completed.add(this);
+            endTimeMs.set(System.currentTimeMillis());
         }
     }
 }

--- a/src/extension/vectortiles/src/test/java/org/geoserver/wms/vector/VectorTileMetatilingTest.java
+++ b/src/extension/vectortiles/src/test/java/org/geoserver/wms/vector/VectorTileMetatilingTest.java
@@ -4,6 +4,9 @@
  */
 package org.geoserver.wms.vector;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -124,8 +127,28 @@ public class VectorTileMetatilingTest extends GeoServerSystemTestSupport {
         int z = 9, x = 510, y = 254;
         VectorTileDecoder decoder = new VectorTileDecoder();
 
+        // Issue the first request — this triggers the metatile render which seeds sibling tiles.
+        MockHttpServletResponse firstResp = getTile(z, x, y);
+        assertEquals(200, firstResp.getStatus());
+        byte[] firstData = firstResp.getContentAsByteArray();
+        assertCacheResult(firstResp, cacheResults[0][0]);
+        assertTrue(firstData.length > 0);
+        assertFeature(decoder, firstData, 0, 0);
+
+        // When metatiling is enabled, sibling tiles are stored asynchronously after the first
+        // request completes. Wait for the cache to be populated before asserting HIT on them.
+        if (cacheResults[0][1] == CacheResult.HIT) {
+            await().atMost(5, SECONDS).pollInterval(100, MILLISECONDS).untilAsserted(() -> {
+                MockHttpServletResponse probe = getTile(z, x + 1, y);
+                assertEquals(200, probe.getStatus());
+                assertCacheResult(probe, CacheResult.HIT);
+            });
+        }
+
+        // Now assert the remaining tiles
         for (int j = 0; j < 2; j++) {
             for (int i = 0; i < 2; i++) {
+                if (j == 0 && i == 0) continue; // already asserted above
                 MockHttpServletResponse resp = getTile(z, x + i, y + j);
                 assertEquals(200, resp.getStatus());
                 byte[] data = resp.getContentAsByteArray();

--- a/src/gwc/src/test/java/org/geoserver/gwc/GWCIntegrationTest.java
+++ b/src/gwc/src/test/java/org/geoserver/gwc/GWCIntegrationTest.java
@@ -640,6 +640,10 @@ public class GWCIntegrationTest extends GeoServerSystemTestSupport {
 
         final TileLayer tileLayer = gwc.getTileLayerByName(qualifiedName);
         assertNotNull(tileLayer);
+
+        // Ensure clean cache state regardless of test execution order
+        gwc.truncate(qualifiedName);
+
         boolean directWMSIntegrationEndpoint = true;
         String request = TEST_WORKSPACE_NAME
                 + "/"


### PR DESCRIPTION
Combined PR for testing all flaky test fixes together:

## Workflow Fix: Remove noop sync context

Removes `aether.syncContext.named.factory=noop` from 5 CI workflows (linux, linux_locales, linux_timezone, macos, windows).

**History**: Added by Andrea in May 2025 (e1b6e67) as a workaround for MNG-7868 lock acquisition failures during parallel builds. However, disabling ALL locking during `-T1C` parallel builds causes intermittent classpath corruption:
- `ExceptionInInitializerError` in webjars/commons-fileupload2 static initializers
- `NoSuchMethodError` on recently-updated dependencies  
- `ClassNotFoundException` for classes in modules built in parallel

Maven Resolver docs explicitly state noop is "for experimenting only". The correct approach for single-process parallel builds is Maven's default `rwlock-local` factory (JVM-level read-write locks), which requires no explicit configuration.

**References**:
- https://issues.apache.org/jira/browse/MNG-7868
- https://maven.apache.org/components/resolver/maven-resolver-named-locks/analyzing-lock-issues.html

## Merged Flaky Test Fixes

- Part 1: Fix flaky metadata extension tests (TabsTest - dynamic tab lookup)
- Part 2: Fix flaky GWCIntegrationTest (truncate cache before assertion)
- Part 5: Fix flaky TemplatePageTest (ensure config loaded in parent @Before)